### PR TITLE
Draft of a section on systemd timer-based renewal

### DIFF
--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -519,7 +519,7 @@ A `tls-renewer@postgres.timer` will always trigger a corresponding `tls-renewer@
 
 So, instead of enabling the `tls-renewer` service units directly, we'll enable timer units that will trigger each service unit.
 
-Here's a timer unit template:
+Here's the timer unit template:
 
 ```
 $ cat << EOF | sudo tee /etc/systemd/system/tls-renewer@.timer > /dev/null
@@ -546,6 +546,8 @@ $ systemctl daemon-reload
 
 Timers using this template will run every 5-10 minutes, with a random delay for each timer.
 
+You can override your timer units too, but you probably won't need to.
+
 With this file in place,
 let's start timers for our `postgres` and `grafana` renewer services:
 
@@ -560,9 +562,10 @@ $ systemctl list-timers
 NEXT                        LEFT          LAST                        PASSED       UNIT                            ACTIVATES
 Wed 2020-12-16 17:06:23 PST 8min left     n/a                         n/a          tls-renewer@postgres.timer      tls-renewer@postgres.service
 Wed 2020-12-16 17:04:12 PST 6min left     n/a                         n/a          tls-renewer@grafana.timer       tls-renewer@grafana.service
+...
 ```
 
-Continue to add service unit overrides (as needed) and start timers for each service requiring TLS certificate renewal.
+Your timers are now running.
 
 #### `cron`-based renewal
 

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -421,16 +421,16 @@ sudo systemctl enable step
   </div>
 </Alert>
 
-
-[Service unit templates](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) and [timers](https://wiki.archlinux.org/index.php/Systemd/Timers) in `systemd` can be used to regularly renew many certificates on a system,
+[Service templates](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) and [timers](https://wiki.archlinux.org/index.php/Systemd/Timers) in `systemd` can be orchestrated to regularly renew many certificates on a system,
 with a bit more flexiblity than the `step renew` daemon.
 
-With this approach, `systemd` will test your certificates regularly (eg. every five minutes), and renew them when they're ready.
+With this approach, you'll create systemd services that renew your certificates,
+and corresponding systemd timers that make sure those services run every few minutes.
 
 In `/etc/systemd/system`, we'll start by creating template files `tls-renewer@.service`, and `tls-renewer@.timer`.
 
 These templates accept a single argument after the `@`.
-For example, for `tls-renewer@kafka.service`, the _service unit argument_ is `kafka`.
+For example, for `tls-renewer@postgres.service`, the _service unit argument_ is `postgres`.
 
 Let's review the service template first, then we'll look at the timer template.
 
@@ -453,7 +453,7 @@ Environment=STEPPATH=/etc/step-ca \
 ; ExecCondition checks if the certificate is ready for renewal,
 ; based on the exit status of the command.
 ExecCondition=/usr/bin/bash -c \
-  'step certificate inspect ${CERT_LOCATION} --format json | \
+  'step certificate inspect ${CERT_LOCATION} --format json --roots "${STEPPATH}/certs/root_ca.crt" | \
   jq -e "(((.validity.start | fromdate) + \
           ((.validity.end | fromdate) - (.validity.start | fromdate)) * 0.66) \
            - now) <= 0" > /dev/null'
@@ -467,37 +467,55 @@ EOF
 $ systemctl daemon-reload
 ```
 
-With this file in place,
-if you have a service called `postgresql`,
-and your certificate is located in `/etc/step-ca/certs/postgresql.crt`.
-you can manually run `systemctl start tls-renewer@postgresql.service`
-and systemd will immediately check the certificate's readiness for renewal, and potentially
-attempt to renew it.
+With this template file in place, we can now ask systemd to start any `tls-renewer@*.service`.
 
-#### Customizing the service template
+So, for example,
+if you have a service called `postgres`,
+with certificate and key files located in `/etc/step-ca/certs/postgres.crt` and `/etc/step-ca/certs/postgres.key`,
+you can manually run `systemctl start tls-renewer@postgres.service`
+and systemd will immediately check that certificate's readiness for renewal, and potentially renew it.
 
-You'll often need to customize the template for a given service.
-For example, here's a service unit customization for Grafana,
-which you would place in `/etc/systemd/system/tls-renewer@grafana.service.d/overrides.conf`:
+#### Customizing a service unit
+
+You'll often need to customize your service unit for a specific use case.
+Many services may need to either be sent a `SIGHUP` signal, or restarted entirely, in order to adopt a renewed TLS certificate.
+
+This is where _service template overrides_ come in handy.
+
+Here's an example of a service template override for a [Lighttpd](https://www.lighttpd.net/) server.
+This file would go into `/etc/systemd/system/tls-renewer@lighttpd.service.d/overrides.conf`:
+
+```
+[Service]
+; Note: `Environment=` overrides are applied per environment variable, not for the entire `Environments=` line.
+Environment=CERT_LOCATION=/etc/lighttpd/certs/example.com.crt KEY_LOCATION=/etc/lighttpd/certs/example.com.key
+
+; Send a SIGHUP to Lighttpd after the certificate is successfully renewed.
+ExecStartPost=/usr/bin/bash -c 'kill -HUP $(cat /var/run/lighttpd.pid)'
+```
+
+[Grafana](https://grafana.com/grafana/) is another example.
+Here's a service unit customization for Grafana,
+which you'd place in `/etc/systemd/system/tls-renewer@grafana.service.d/overrides.conf`:
 
 ```
 [Service]
 Environment=CERT_LOCATION=/etc/grafana/grafana.crt KEY_LOCATION=/etc/grafana/grafana.key
+
+; Restart Grafana after the certificate is successfully renewed.
 ExecStartPost=systemctl restart grafana-server
+
+; Alert a health check service that our certificate has successfully been renewed.
 ExecStartPost=curl -m 10 --retry 5 https://hc-ping.com/xxxxxx
 ```
 
-This override sets the cert and key locations,
-restarts Grafana after the certificate is successfully renewed,
-and calls a health check endpoint to indicate successful renewal.
-
-Note that `Environment=` overrides are applied per environment variable,
-not for the entire `Environments=` line.
+In this case, we're restarting grafana entirely,
+and we're calling out to a health check service that expects to see a ping from us each day, when the certificate is renewed.
 
 #### Enabling `systemd` renewal timers
 
 Timers and services go hand in hand in systemd:
-A `tls-renewer@kafka.timer` will always trigger a corresponding `tls-renewer@kafka.service`.
+A `tls-renewer@postgres.timer` will always trigger a corresponding `tls-renewer@postgres.service`.
 
 So, instead of enabling the `tls-renewer` service units directly, we'll enable timer units that will trigger each service unit.
 
@@ -529,13 +547,13 @@ $ systemctl daemon-reload
 Timers using this template will run every 5-10 minutes, with a random delay for each timer.
 
 With this file in place,
-let's start timers for our `postgresql` and `grafana` renewer services:
+let's start timers for our `postgres` and `grafana` renewer services:
 
 ```shell-session
-$ systemctl start tls-renewer@postgresql.timer
+$ systemctl start tls-renewer@postgres.timer
 $ systemctl start tls-renewer@grafana.timer
-$ systemctl enable tls-renewer@postgresql.timer
-Created symlink /etc/systemd/system/multi-user.target.wants/tls-renewer@postgresql.service → /etc/systemd/system/tls-renewer@.service.
+$ systemctl enable tls-renewer@postgres.timer
+Created symlink /etc/systemd/system/multi-user.target.wants/tls-renewer@postgres.service → /etc/systemd/system/tls-renewer@.service.
 $ systemctl enable tls-renewer@grafana.timer
 Created symlink /etc/systemd/system/multi-user.target.wants/tls-renewer@grafana.service → /etc/systemd/system/tls-renewer@.service.
 $ systemctl list-timers

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -345,15 +345,176 @@ _Note the change in the validity period relative to the original certificate abo
 The `step ca renew` command includes tools that simplify automated renewal. After all, what good are short-lived certificates if we can't renew them automatically?
 
 Here are three options for setting up automated renewal of certificates with `step ca renew`:
-* [The standalone renewal daemon](#the-standalone-renewal-daemon)
-* [Renewal using `systemd` timers](#renewal-using-systemd-timers)
+* [Renewal using `systemd` timers](#renewal-using-systemd-timers) (This is the preferred approach.)
+* [The standalone `step` renewal daemon](#the-standalone-step-renewal-daemon)
 * [`cron`-based renewal](#-cron-based-renewal)
 
-The `systemd`-based approach is preferred.
+#### Renewal using `systemd` timers
 
-#### The standalone renewal daemon
+<Alert severity="info">
+  <div>
+    Note: This approach requires the <a href="https://stedolan.github.io/jq/"><code>jq</code> command</a> to be installed
+    on the target system.
+  </div>
+</Alert>
 
-You can automate renewal by running `step ca renew` as a daemon that will keep your certificates up-to-date:
+[Service templates](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) and [timers](https://wiki.archlinux.org/index.php/Systemd/Timers) in `systemd` can be orchestrated to regularly renew many certificates on a system.
+
+With this approach, you'll create systemd services that renew your certificates,
+and corresponding systemd timers that make sure those services run every few minutes.
+
+In `/etc/systemd/system`, we'll start by creating template files `cert-renewer@.service`, and `cert-renewer@.timer`.
+
+These templates accept a single argument after the `@`.
+For example, for `cert-renewer@postgres.service`, the _service unit argument_ is `postgres`.
+
+Let's review the service template first, then we'll look at the timer template.
+
+```shell-session
+$ cat <<EOF | sudo tee /etc/systemd/system/cert-renewer@.service > /dev/null
+[Unit]
+Description=TLS certificate renewer for %I
+After=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+User=root
+
+; `%i` is replaced with the service unit argument,
+; eg. for 'cert-renewer@kafka.service', %i is 'kafka'
+Environment=STEPPATH=/etc/step-ca \
+            CERT_LOCATION=/etc/step/certs/%i.crt \
+            KEY_LOCATION=/etc/step/certs/%i.key
+
+; ExecCondition checks if the certificate is ready for renewal,
+; based on the exit status of the command.
+ExecCondition=/usr/bin/bash -c \
+  'step certificate inspect $CERT_LOCATION --format json --roots "$STEPPATH/certs/root_ca.crt" | \
+  jq -e "(((.validity.start | fromdate) + \
+          ((.validity.end | fromdate) - (.validity.start | fromdate)) * 0.66) \
+           - now) <= 0" > /dev/null'
+
+; ExecStart renews the certificate, if ExecCondition was successful.
+ExecStart=/usr/bin/step ca renew --force $CERT_LOCATION $KEY_LOCATION
+
+; Try to reload or restart the systemd service that parallels this cert-renewer
+ExecStartPost=/usr/bin/bash -c 'systemctl --quiet is-enabled %i && systemctl try-reload-or-restart %i'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+$ systemctl daemon-reload
+```
+
+With this template file in place, we can now ask systemd to start any `cert-renewer@*.service`.
+
+So, for example, if you have a systemd service called `postgres`,
+with certificate and key files located in `/etc/step/certs/postgres.crt` and `/etc/step/certs/postgres.key`,
+you can manually run `systemctl start cert-renewer@postgres.service`
+and systemd will immediately check that certificate's readiness for renewal, and potentially renew it.
+
+If the certificate is renewed, the `ExecPostStart` command will run and the `postgres` service will be reloaded or restarted.
+
+#### Customizing a service unit
+
+You'll often need to customize your service unit for a specific use case.
+For example, you may need to:
+* Reload or restart more services, or services not managed by systemd
+* Change the location of certficate files for a service
+* Run `step` with a different `STEPPATH` or as a different user (eg. to access a different CA)
+* Ping a health check service or perform another action after a specific certificate is renewed
+
+This is where _service template overrides_ come in handy.
+
+Here's an example of a service template override for a [Lighttpd](https://www.lighttpd.net/) server that
+uses docker-compose and is not managed by systemd.
+This file would go into `/etc/systemd/system/cert-renewer@docker-lighttpd.service.d/overrides.conf`:
+
+```
+[Service]
+; Note: `Environment=` overrides are applied per environment variable, not for the entire `Environments=` line.
+Environment=CERT_LOCATION=/etc/docker/compose/lighttpd/certs/example.com.crt \
+            KEY_LOCATION=/etc/docker/compose/lighttpd/certs/example.com.key
+WorkingDirectory=/etc/docker/compose/lighttpd
+
+; Restart docker containers after the certificate is successfully renewed.
+ExecStartPost=/usr/local/bin/docker-compose restart
+```
+
+Here's another example for [Grafana](https://grafana.com/grafana/),
+which you'd place in `/etc/systemd/system/cert-renewer@grafana-server.service.d/overrides.conf`:
+
+```
+[Service]
+Environment=CERT_LOCATION=/etc/grafana/grafana.crt KEY_LOCATION=/etc/grafana/grafana.key
+
+; Alert a health check service that our certificate has successfully been renewed.
+ExecStartPost=curl -m 10 --retry 5 https://hc-ping.com/xxxxxx
+```
+
+In this case, when the certificate is renewed, the renewer will restart `grafana-server.service`,
+then out to a health check service that expects to see a ping from this unit each day.
+
+#### Enabling `systemd` renewal timers
+
+Timers and services go hand in hand in systemd:
+A `cert-renewer@postgres.timer` will always trigger a corresponding `cert-renewer@postgres.service`.
+
+So, instead of enabling the `cert-renewer` service units directly, we'll enable timer units that will trigger each service unit.
+
+Here's the timer unit template:
+
+```
+$ cat << EOF | sudo tee /etc/systemd/system/cert-renewer@.timer > /dev/null
+[Unit]
+Description=TLS certificate renewal timer for %I
+
+[Timer]
+Persistent=true
+
+; Run the timer unit every 5 minutes.
+OnCalendar=*:1/5
+
+; Always run the timer on time.
+AccuracySec=1us
+
+; Add jitter to prevent a "thundering hurd" of simultaneous certificate renewals.
+RandomizedDelaySec=5m
+
+[Install]
+WantedBy=timers.target
+EOF
+$ systemctl daemon-reload
+```
+
+Timers using this template will run every 5-10 minutes, with a random delay for each timer.
+
+You can override your timer units too, but you probably won't need to.
+
+With this file in place,
+let's start timers for our `postgres` and `grafana-server` renewer services:
+
+```shell-session
+$ systemctl start cert-renewer@postgres.timer
+$ systemctl start cert-renewer@grafana-server.timer
+$ systemctl enable cert-renewer@postgres.timer
+Created symlink /etc/systemd/system/multi-user.target.wants/cert-renewer@postgres.service → /etc/systemd/system/cert-renewer@.service.
+$ systemctl enable cert-renewer@grafana-server.timer
+Created symlink /etc/systemd/system/multi-user.target.wants/cert-renewer@grafana-server.service → /etc/systemd/system/cert-renewer@.service.
+$ systemctl list-timers
+NEXT                        LEFT          LAST                        PASSED       UNIT                                    ACTIVATES
+Wed 2020-12-16 17:06:23 PST 8min left     n/a                         n/a          cert-renewer@postgres.timer             cert-renewer@postgres.service
+Wed 2020-12-16 17:04:12 PST 6min left     n/a                         n/a          cert-renewer@grafana-server.timer       cert-renewer@grafana-server.service
+...
+```
+
+Your timers are now running.
+
+#### The standalone `step` renewal daemon
+
+Another way to automate renewal is with the `step` renewal daemon.
+With this method, `step ca renew` operates as a daemon that will keep your certificates up-to-date:
 
 ```shell-session nocopy
 $ step ca renew --daemon foo.crt foo.key
@@ -365,9 +526,11 @@ POST https://localhost/renew failed: Post https://localhost/renew: dial tcp [::1
 INFO: 2019/06/22 11:05:00 certificate renewed, next in 14h33m17s
 ```
 
-When daemonized, `step ca renew` will attempt a renewal when the certificate's lifetime is approximately two-thirds elapsed. So, for a certificate with a 24 hour lifetime, it will attempt a renewal in about 16 hours.
+When daemonized, `step ca renew` will attempt a renewal when the certificate's lifetime is approximately two-thirds elapsed.
+So, for a certificate with a 24 hour lifetime, it will attempt a renewal after about 16 hours.
 
-There is some random _jitter_ built into the daemon's schedule to prevent a large number of renewals from being sent to the CA by a multitude of virtual machines that were provisioned at the same time.  This helps with [thundering herd problems](https://en.wikipedia.org/wiki/Thundering_herd_problem) if many virtual machines that were provisioned together have certificates with identical expiration dates.
+There is some random _jitter_ built into the daemon's schedule to prevent a large number of renewals from being sent to the CA simultaneously
+(eg. by a multitude of virtual machines that were provisioned at the same time and have identical certificate expiration dates).
 
 If the CA is unreachable, renewals are retried every minute.
 
@@ -411,161 +574,6 @@ And tell systemd to restart it on reboot:
 sudo systemctl enable step
 ```
 
-#### Renewal using `systemd` timers
-
-
-<Alert severity="info">
-  <div>
-    Note: This approach requires the <a href="https://stedolan.github.io/jq/"><code>jq</code> command</a> to be installed
-    on the target system.
-  </div>
-</Alert>
-
-[Service templates](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) and [timers](https://wiki.archlinux.org/index.php/Systemd/Timers) in `systemd` can be orchestrated to regularly renew many certificates on a system,
-with a bit more flexiblity than the `step renew` daemon.
-
-With this approach, you'll create systemd services that renew your certificates,
-and corresponding systemd timers that make sure those services run every few minutes.
-
-In `/etc/systemd/system`, we'll start by creating template files `tls-renewer@.service`, and `tls-renewer@.timer`.
-
-These templates accept a single argument after the `@`.
-For example, for `tls-renewer@postgres.service`, the _service unit argument_ is `postgres`.
-
-Let's review the service template first, then we'll look at the timer template.
-
-```shell-session
-$ cat <<EOF | sudo tee /etc/systemd/system/tls-renewer@.service > /dev/null
-[Unit]
-Description=TLS certificate renewer for %I
-After=network-online.target
-StartLimitIntervalSec=0
-
-[Service]
-Type=oneshot
-User=root
-
-; `%i` is replaced with the service unit argument, eg. 'kafka'
-Environment=STEPPATH=/etc/step-ca \
-            CERT_LOCATION=/etc/step-ca/certs/%i.crt \
-            KEY_LOCATION=/etc/step-ca/certs/%i.key
-
-; ExecCondition checks if the certificate is ready for renewal,
-; based on the exit status of the command.
-ExecCondition=/usr/bin/bash -c \
-  'step certificate inspect ${CERT_LOCATION} --format json --roots "${STEPPATH}/certs/root_ca.crt" | \
-  jq -e "(((.validity.start | fromdate) + \
-          ((.validity.end | fromdate) - (.validity.start | fromdate)) * 0.66) \
-           - now) <= 0" > /dev/null'
-
-; ExecStart renews the certificate, if ExecCondition was successful.
-ExecStart=/usr/bin/step ca renew --force ${CERT_LOCATION} ${KEY_LOCATION}
-
-[Install]
-WantedBy=multi-user.target
-EOF
-$ systemctl daemon-reload
-```
-
-With this template file in place, we can now ask systemd to start any `tls-renewer@*.service`.
-
-So, for example,
-if you have a service called `postgres`,
-with certificate and key files located in `/etc/step-ca/certs/postgres.crt` and `/etc/step-ca/certs/postgres.key`,
-you can manually run `systemctl start tls-renewer@postgres.service`
-and systemd will immediately check that certificate's readiness for renewal, and potentially renew it.
-
-#### Customizing a service unit
-
-You'll often need to customize your service unit for a specific use case.
-Many services may need to either be sent a `SIGHUP` signal, or restarted entirely, in order to adopt a renewed TLS certificate.
-
-This is where _service template overrides_ come in handy.
-
-Here's an example of a service template override for a [Lighttpd](https://www.lighttpd.net/) server.
-This file would go into `/etc/systemd/system/tls-renewer@lighttpd.service.d/overrides.conf`:
-
-```
-[Service]
-; Note: `Environment=` overrides are applied per environment variable, not for the entire `Environments=` line.
-Environment=CERT_LOCATION=/etc/lighttpd/certs/example.com.crt KEY_LOCATION=/etc/lighttpd/certs/example.com.key
-
-; Send a SIGHUP to Lighttpd after the certificate is successfully renewed.
-ExecStartPost=/usr/bin/bash -c 'kill -HUP $(cat /var/run/lighttpd.pid)'
-```
-
-[Grafana](https://grafana.com/grafana/) is another example.
-Here's a service unit customization for Grafana,
-which you'd place in `/etc/systemd/system/tls-renewer@grafana.service.d/overrides.conf`:
-
-```
-[Service]
-Environment=CERT_LOCATION=/etc/grafana/grafana.crt KEY_LOCATION=/etc/grafana/grafana.key
-
-; Restart Grafana after the certificate is successfully renewed.
-ExecStartPost=systemctl restart grafana-server
-
-; Alert a health check service that our certificate has successfully been renewed.
-ExecStartPost=curl -m 10 --retry 5 https://hc-ping.com/xxxxxx
-```
-
-In this case, we're restarting grafana entirely,
-and we're calling out to a health check service that expects to see a ping from us each day, when the certificate is renewed.
-
-#### Enabling `systemd` renewal timers
-
-Timers and services go hand in hand in systemd:
-A `tls-renewer@postgres.timer` will always trigger a corresponding `tls-renewer@postgres.service`.
-
-So, instead of enabling the `tls-renewer` service units directly, we'll enable timer units that will trigger each service unit.
-
-Here's the timer unit template:
-
-```
-$ cat << EOF | sudo tee /etc/systemd/system/tls-renewer@.timer > /dev/null
-[Unit]
-Description=TLS certificate renewal timer for %I
-
-[Timer]
-Persistent=true
-
-; Run the timer unit every 5 minutes.
-OnCalendar=*:1/5
-
-; Always run the timer on time.
-AccuracySec=1us
-
-; Add jitter to prevent a "thundering hurd" of simultaneous certificate renewals.
-RandomizedDelaySec=5m
-
-[Install]
-WantedBy=timers.target
-EOF
-$ systemctl daemon-reload
-```
-
-Timers using this template will run every 5-10 minutes, with a random delay for each timer.
-
-You can override your timer units too, but you probably won't need to.
-
-With this file in place,
-let's start timers for our `postgres` and `grafana` renewer services:
-
-```shell-session
-$ systemctl start tls-renewer@postgres.timer
-$ systemctl start tls-renewer@grafana.timer
-$ systemctl enable tls-renewer@postgres.timer
-Created symlink /etc/systemd/system/multi-user.target.wants/tls-renewer@postgres.service → /etc/systemd/system/tls-renewer@.service.
-$ systemctl enable tls-renewer@grafana.timer
-Created symlink /etc/systemd/system/multi-user.target.wants/tls-renewer@grafana.service → /etc/systemd/system/tls-renewer@.service.
-$ systemctl list-timers
-NEXT                        LEFT          LAST                        PASSED       UNIT                            ACTIVATES
-Wed 2020-12-16 17:06:23 PST 8min left     n/a                         n/a          tls-renewer@postgres.timer      tls-renewer@postgres.service
-Wed 2020-12-16 17:04:12 PST 6min left     n/a                         n/a          tls-renewer@grafana.timer       tls-renewer@grafana.service
-...
-```
-
-Your timers are now running.
 
 #### `cron`-based renewal
 

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -323,7 +323,9 @@ practice.
 
 ### Manual Renewal
 
-With short-lived certificates, your services and hosts will need to renew their certificates regularly, by extending their lifetimes _before they expire_. You can do this with the following command:
+With short-lived certificates, your services and hosts will need to renew their certificates regularly, by extending their lifetimes _before they expire_.
+
+You can do this with the following command:
 
 <CodeBlock language="shell" copyText="step ca renew --force foo.crt foo.key">
 {`$ step ca renew --force foo.crt foo.key
@@ -342,12 +344,14 @@ _Note the change in the validity period relative to the original certificate abo
 
 ### Automated renewal
 
-The `step ca renew` command includes tools that simplify automated renewal. After all, what good are short-lived certificates if we can't renew them automatically?
+What good are short-lived certificates if we can't renew them automatically?
 
 Here are three options for setting up automated renewal of certificates with `step ca renew`:
-* [Renewal using `systemd` timers](#renewal-using-systemd-timers) (This is the preferred approach.)
-* [The standalone `step` renewal daemon](#the-standalone-step-renewal-daemon)
-* [`cron`-based renewal](#-cron-based-renewal)
+* [Renewal using `systemd` timers](#renewal-using-systemd-timers). This is the preferred approach.
+
+* [The standalone `step` renewal daemon](#the-standalone-step-renewal-daemon).
+
+* [`cron`-based renewal](#-cron-based-renewal).
 
 #### Renewal using `systemd` timers
 
@@ -358,22 +362,24 @@ Here are three options for setting up automated renewal of certificates with `st
   </div>
 </Alert>
 
-[Service templates](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) and [timers](https://wiki.archlinux.org/index.php/Systemd/Timers) in `systemd` can be orchestrated to regularly renew many certificates on a system.
+With this approach, a systemd service will renew your certificate after 2/3 of its lifetime has elapsed,
+and a corresponding [systemd timer](https://wiki.archlinux.org/index.php/Systemd/Timers) will run the service periodically for you.
 
-With this approach, you'll create systemd services that renew your certificates,
-and corresponding systemd timers that make sure those services run every few minutes.
+We will leverage systemd [service templates](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates)
+to simplify configuration of certificate renewal for many target services.
 
 In `/etc/systemd/system`, we'll start by creating template files `cert-renewer@.service`, and `cert-renewer@.timer`.
 
-These templates accept a single argument after the `@`.
-For example, for `cert-renewer@postgres.service`, the _service unit argument_ is `postgres`.
+Service templates accept a single argument after the `@`, called the _service unit argument_.
+For example, for `cert-renewer@postgresql.service`, the service unit argument is `postgresql`.
+In the template, `%i` represents the service unit argument.
 
 Let's review the service template first, then we'll look at the timer template.
 
 ```shell-session
 $ cat <<EOF | sudo tee /etc/systemd/system/cert-renewer@.service > /dev/null
 [Unit]
-Description=TLS certificate renewer for %I
+Description=Certificate renewer for %I
 After=network-online.target
 StartLimitIntervalSec=0
 
@@ -381,8 +387,6 @@ StartLimitIntervalSec=0
 Type=oneshot
 User=root
 
-; `%i` is replaced with the service unit argument,
-; eg. for 'cert-renewer@kafka.service', %i is 'kafka'
 Environment=STEPPATH=/etc/step-ca \
             CERT_LOCATION=/etc/step/certs/%i.crt \
             KEY_LOCATION=/etc/step/certs/%i.key
@@ -398,7 +402,7 @@ ExecCondition=/usr/bin/bash -c \
 ; ExecStart renews the certificate, if ExecCondition was successful.
 ExecStart=/usr/bin/step ca renew --force $CERT_LOCATION $KEY_LOCATION
 
-; Try to reload or restart the systemd service that parallels this cert-renewer
+; Try to reload or restart the systemd service that relies on this cert-renewer
 ExecStartPost=/usr/bin/bash -c 'systemctl --quiet is-enabled %i && systemctl try-reload-or-restart %i'
 
 [Install]
@@ -407,43 +411,49 @@ EOF
 $ systemctl daemon-reload
 ```
 
-With this template file in place, we can now ask systemd to start any `cert-renewer@*.service`.
+So, with this template file in place, we can now ask systemd to start any `cert-renewer@*.service`.
 
-So, for example, if you have a systemd service called `postgres`,
-with certificate and key files located in `/etc/step/certs/postgres.crt` and `/etc/step/certs/postgres.key`,
-you can manually run `systemctl start cert-renewer@postgres.service`
+For example, if you have a systemd service called `postgresql.service`,
+with certificate and key files located in `/etc/step/certs/postgresql.crt` and `/etc/step/certs/postgresql.key`,
+you can manually run `systemctl start cert-renewer@postgresql.service`
 and systemd will immediately check that certificate's readiness for renewal, and potentially renew it.
-
-If the certificate is renewed, the `ExecPostStart` command will run and the `postgres` service will be reloaded or restarted.
+If the certificate is successfully renewed, the `postgresql` service will be reloaded or restarted.
 
 #### Customizing a service unit
 
-You'll often need to customize your service unit for a specific use case.
+You'll often need to customize your service unit for a given service.
+
 For example, you may need to:
-* Reload or restart more services, or services not managed by systemd
+* Reload or restart additional services
+
 * Change the location of certficate files for a service
-* Run `step` with a different `STEPPATH` or as a different user (eg. to access a different CA)
+
+* Run `step` with a different `$STEPPATH` (eg. to access a different CA)
+
 * Ping a health check service or perform another action after a specific certificate is renewed
 
-This is where _service template overrides_ come in handy.
+Instead of modifying the service template, we'll use _service template overrides_ here.
+The overrides live in the drop-in configuration directory for the service being custommized.
 
-Here's an example of a service template override for a [Lighttpd](https://www.lighttpd.net/) server that
-uses docker-compose and is not managed by systemd.
-This file would go into `/etc/systemd/system/cert-renewer@docker-lighttpd.service.d/overrides.conf`:
+Here's an example override for a [Lighttpd](https://www.lighttpd.net/) service that uses Docker Compose and is not managed by systemd:
+
+`/etc/systemd/system/cert-renewer@lighttpd-docker.service.d/overrides.conf`:
 
 ```
 [Service]
-; Note: `Environment=` overrides are applied per environment variable, not for the entire `Environments=` line.
+; `Environment=` overrides are applied per environment variable. This line does not
+; affect any other variables set in the service template.
 Environment=CERT_LOCATION=/etc/docker/compose/lighttpd/certs/example.com.crt \
             KEY_LOCATION=/etc/docker/compose/lighttpd/certs/example.com.key
 WorkingDirectory=/etc/docker/compose/lighttpd
 
-; Restart docker containers after the certificate is successfully renewed.
+; Restart lighttpd docker containers after the certificate is successfully renewed.
 ExecStartPost=/usr/local/bin/docker-compose restart
 ```
 
-Here's another example for [Grafana](https://grafana.com/grafana/),
-which you'd place in `/etc/systemd/system/cert-renewer@grafana-server.service.d/overrides.conf`:
+Here's another example of an override for [Grafana](https://grafana.com/grafana/).
+
+`/etc/systemd/system/cert-renewer@grafana-server.service.d/overrides.conf`:
 
 ```
 [Service]
@@ -453,22 +463,22 @@ Environment=CERT_LOCATION=/etc/grafana/grafana.crt KEY_LOCATION=/etc/grafana/gra
 ExecStartPost=curl -m 10 --retry 5 https://hc-ping.com/xxxxxx
 ```
 
-In this case, when the certificate is renewed, the renewer will restart `grafana-server.service`,
-then out to a health check service that expects to see a ping from this unit each day.
+When the certificate is successfully renewed, the service template will reload or restart `grafana-server.service`,
+and the override configuration will ping a health check service that expects to hear from this unit each day.
 
 #### Enabling `systemd` renewal timers
 
-Timers and services go hand in hand in systemd:
-A `cert-renewer@postgres.timer` will always trigger a corresponding `cert-renewer@postgres.service`.
+The final piece of the puzzle is the renewal timer. Timers and services go hand in hand in systemd:
+A `cert-renewer@postgresql.timer` will always trigger a corresponding `cert-renewer@postgresql.service`.
 
-So, instead of enabling the `cert-renewer` service units directly, we'll enable timer units that will trigger each service unit.
+Therefore, instead of enabling the `cert-renewer@*.service` service units directly, we'll enable timer units that will periodically trigger each service unit.
 
 Here's the timer unit template:
 
 ```
 $ cat << EOF | sudo tee /etc/systemd/system/cert-renewer@.timer > /dev/null
 [Unit]
-Description=TLS certificate renewal timer for %I
+Description=Certificate renewal timer for %I
 
 [Timer]
 Persistent=true
@@ -488,28 +498,30 @@ EOF
 $ systemctl daemon-reload
 ```
 
-Timers using this template will run every 5-10 minutes, with a random delay for each timer.
+Timers using this template will run every 5-10 minutes,
+with a randomized delay on each timer.
+The randomized delay helps with [thundering herd problems](https://en.wikipedia.org/wiki/Thundering_herd_problem)
+that can occur when many virtual machines that were provisioned together try to renew their certificates at the same time.
 
-You can override your timer units too, but you probably won't need to.
-
-With this file in place,
-let's start timers for our `postgres` and `grafana-server` renewer services:
+With this template in place,
+let's start timers for our `postgresql` and `grafana-server` renewer services:
 
 ```shell-session
-$ systemctl start cert-renewer@postgres.timer
+$ systemctl start cert-renewer@postgresql.timer
 $ systemctl start cert-renewer@grafana-server.timer
-$ systemctl enable cert-renewer@postgres.timer
-Created symlink /etc/systemd/system/multi-user.target.wants/cert-renewer@postgres.service → /etc/systemd/system/cert-renewer@.service.
+$ systemctl enable cert-renewer@postgresql.timer
+Created symlink /etc/systemd/system/multi-user.target.wants/cert-renewer@postgresql.service → /etc/systemd/system/cert-renewer@.service.
 $ systemctl enable cert-renewer@grafana-server.timer
 Created symlink /etc/systemd/system/multi-user.target.wants/cert-renewer@grafana-server.service → /etc/systemd/system/cert-renewer@.service.
 $ systemctl list-timers
 NEXT                        LEFT          LAST                        PASSED       UNIT                                    ACTIVATES
-Wed 2020-12-16 17:06:23 PST 8min left     n/a                         n/a          cert-renewer@postgres.timer             cert-renewer@postgres.service
+Wed 2020-12-16 17:06:23 PST 8min left     n/a                         n/a          cert-renewer@postgresql.timer             cert-renewer@postgresql.service
 Wed 2020-12-16 17:04:12 PST 6min left     n/a                         n/a          cert-renewer@grafana-server.timer       cert-renewer@grafana-server.service
 ...
 ```
 
-Your timers are now running.
+Your periodic timers are now running and will run on system startup. 
+You can override your timer units too, but you probably won't need to.
 
 #### The standalone `step` renewal daemon
 
@@ -574,6 +586,20 @@ And tell systemd to restart it on reboot:
 sudo systemctl enable step
 ```
 
+#### Notifying Certificate-Dependent Services
+
+Many services that depend on certificates will only read the certificate files on startup.
+So when you renew a certificate, a server process that depends on it may not detect that it has changed.
+
+It's common for services (eg. `nginx`) to respond to a `SIGHUP` signal by reloading configuration files and certificates.
+To address this, `step ca renew` can send a `SIGHUP` to your service after each renewal.
+Here's an example for `nginx`:
+
+```shell-session nocopy
+$ step ca renew --daemon --exec "kill -HUP $NGINX_PID" foo.crt foo.key
+INFO: 2019/05/01 14:22:18 first renewal in 15h50m43s
+```
+
 
 #### `cron`-based renewal
 
@@ -601,17 +627,6 @@ EOF
 Be sure the user (in this example, `step`) has write access to the certificate and key you're renewing.
 
 ### Caveats of Automated Renewal
-
-#### Notifying Certificate-Dependent Services
-
-Many services that depend on certificates will only read the certificate files on startup. So when you renew a certificate, a server process that depends on it may not detect that it has changed.
-
-It's common for services (eg. `nginx`) to respond to a `SIGHUP` signal by reloading configuration files and certificates. To address this, `step ca renew` can send a `SIGHUP` to your service after each renewal. Here's an example for `nginx`:
-
-```shell-session nocopy
-$ step ca renew --daemon --exec "kill -HUP $NGINX_PID" foo.crt foo.key
-INFO: 2019/05/01 14:22:18 first renewal in 15h50m43s
-```
 
 #### Revoking a Certificate
 

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -346,7 +346,7 @@ The `step ca renew` command includes tools that simplify automated renewal. Afte
 
 Here are three options for setting up automated renewal of certificates with `step ca renew`:
 * [The standalone renewal daemon](#the-standalone-renewal-daemon)
-* [`systemd`-based renewal](#-systemd-based-renewal)
+* [Renewal using `systemd` timers](#renewal-using-systemd-timers)
 * [`cron`-based renewal](#-cron-based-renewal)
 
 The `systemd`-based approach is preferred.
@@ -373,8 +373,6 @@ If the CA is unreachable, renewals are retried every minute.
 
 You can trigger renewal anytime by sending a `SIGHUP` signal to the `step ca renew` process ID.
 
-#### `systemd`-based renewal
-
 You can add `step ca renew --daemon` as a `systemd` service that runs on startup and restarts as needed.
 
 Here's an example of setting up everything via `systemd`:
@@ -382,7 +380,7 @@ Here's an example of setting up everything via `systemd`:
 ```shell-session nocopy
 $ cat <<EOF | sudo tee /etc/systemd/system/step.service > /dev/null
 [Unit]
-Description=Automated certificate management
+Description=Step TLS Renewer for Foo service
 After=network.target
 StartLimitIntervalSec=0
 
@@ -396,6 +394,7 @@ ExecStart=/usr/bin/step ca renew --daemon /home/step/foo.crt /home/step/foo.key
 [Install]
 WantedBy=multi-user.target
 EOF
+$ systemctl daemon-reload
 ```
 
 Be sure the `User` has write access to the certificate and key you're renewing.
@@ -412,6 +411,141 @@ And tell systemd to restart it on reboot:
 sudo systemctl enable step
 ```
 
+#### Renewal using `systemd` timers
+
+
+<Alert severity="info">
+  <div>
+    Note: This approach requires the <a href="https://stedolan.github.io/jq/"><code>jq</code> command</a> to be installed
+    on the target system.
+  </div>
+</Alert>
+
+
+[Service unit templates](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Service%20Templates) and [timers](https://wiki.archlinux.org/index.php/Systemd/Timers) in `systemd` can be used to regularly renew many certificates on a system,
+with a bit more flexiblity than the `step renew` daemon.
+
+With this approach, `systemd` will test your certificates regularly (eg. every five minutes), and renew them when they're ready.
+
+In `/etc/systemd/system`, we'll start by creating template files `tls-renewer@.service`, and `tls-renewer@.timer`.
+
+These templates accept a single argument after the `@`.
+For example, for `tls-renewer@kafka.service`, the _service unit argument_ is `kafka`.
+
+Let's review the service template first, then we'll look at the timer template.
+
+```shell-session
+$ cat <<EOF | sudo tee /etc/systemd/system/tls-renewer@.service > /dev/null
+[Unit]
+Description=TLS certificate renewer for %I
+After=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+User=root
+
+; `%i` is replaced with the service unit argument, eg. 'kafka'
+Environment=STEPPATH=/etc/step-ca \
+            CERT_LOCATION=/etc/step-ca/certs/%i.crt \
+            KEY_LOCATION=/etc/step-ca/certs/%i.key
+
+; ExecCondition checks if the certificate is ready for renewal,
+; based on the exit status of the command.
+ExecCondition=/usr/bin/bash -c \
+  'step certificate inspect ${CERT_LOCATION} --format json | \
+  jq -e "(((.validity.start | fromdate) + \
+          ((.validity.end | fromdate) - (.validity.start | fromdate)) * 0.66) \
+           - now) <= 0" > /dev/null'
+
+; ExecStart renews the certificate, if ExecCondition was successful.
+ExecStart=/usr/bin/step ca renew --force ${CERT_LOCATION} ${KEY_LOCATION}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+$ systemctl daemon-reload
+```
+
+With this file in place,
+if you have a service called `postgresql`,
+and your certificate is located in `/etc/step-ca/certs/postgresql.crt`.
+you can manually run `systemctl start tls-renewer@postgresql.service`
+and systemd will immediately check the certificate's readiness for renewal, and potentially
+attempt to renew it.
+
+#### Customizing the service template
+
+You'll often need to customize the template for a given service.
+For example, here's a service unit customization for Grafana,
+which you would place in `/etc/systemd/system/tls-renewer@grafana.service.d/overrides.conf`:
+
+```
+[Service]
+Environment=CERT_LOCATION=/etc/grafana/grafana.crt KEY_LOCATION=/etc/grafana/grafana.key
+ExecStartPost=systemctl restart grafana-server
+ExecStartPost=curl -m 10 --retry 5 https://hc-ping.com/xxxxxx
+```
+
+This override sets the cert and key locations,
+restarts Grafana after the certificate is successfully renewed,
+and calls a health check endpoint to indicate successful renewal.
+
+Note that `Environment=` overrides are applied per environment variable,
+not for the entire `Environments=` line.
+
+#### Enabling `systemd` renewal timers
+
+Timers and services go hand in hand in systemd:
+A `tls-renewer@kafka.timer` will always trigger a corresponding `tls-renewer@kafka.service`.
+
+So, instead of enabling the `tls-renewer` service units directly, we'll enable timer units that will trigger each service unit.
+
+Here's a timer unit template:
+
+```
+$ cat << EOF | sudo tee /etc/systemd/system/tls-renewer@.timer > /dev/null
+[Unit]
+Description=TLS certificate renewal timer for %I
+
+[Timer]
+Persistent=true
+
+; Run the timer unit every 5 minutes.
+OnCalendar=*:1/5
+
+; Always run the timer on time.
+AccuracySec=1us
+
+; Add jitter to prevent a "thundering hurd" of simultaneous certificate renewals.
+RandomizedDelaySec=5m
+
+[Install]
+WantedBy=timers.target
+EOF
+$ systemctl daemon-reload
+```
+
+Timers using this template will run every 5-10 minutes, with a random delay for each timer.
+
+With this file in place,
+let's start timers for our `postgresql` and `grafana` renewer services:
+
+```shell-session
+$ systemctl start tls-renewer@postgresql.timer
+$ systemctl start tls-renewer@grafana.timer
+$ systemctl enable tls-renewer@postgresql.timer
+Created symlink /etc/systemd/system/multi-user.target.wants/tls-renewer@postgresql.service → /etc/systemd/system/tls-renewer@.service.
+$ systemctl enable tls-renewer@grafana.timer
+Created symlink /etc/systemd/system/multi-user.target.wants/tls-renewer@grafana.service → /etc/systemd/system/tls-renewer@.service.
+$ systemctl list-timers
+NEXT                        LEFT          LAST                        PASSED       UNIT                            ACTIVATES
+Wed 2020-12-16 17:06:23 PST 8min left     n/a                         n/a          tls-renewer@postgres.timer      tls-renewer@postgres.service
+Wed 2020-12-16 17:04:12 PST 6min left     n/a                         n/a          tls-renewer@grafana.timer       tls-renewer@grafana.service
+```
+
+Continue to add service unit overrides (as needed) and start timers for each service requiring TLS certificate renewal.
+
 #### `cron`-based renewal
 
 With `cron`-based renewal, you can have `step ca renew` run at a regular cadence (eg. every five minutes) and renew a certificate only when it's approaching its expiration date.
@@ -425,7 +559,7 @@ $ step ca renew --force --expires-in 24h foo.crt foo.key
 Your certificate has been saved in foo.crt.
 ```
 
-With `--expires-in`, we add a _jitter_ to `<duration>` (a random amount between 0 and `<duration>/20`). This helps with [thundering herd problems](https://en.wikipedia.org/wiki/Thundering_herd_problem) if many virtual machines that were provisioned together try to renew their certificates at the same time.
+With `--expires-in`, we add a random _jitter_ to `<duration>` (between 0 and `<duration>/20`). This helps with [thundering herd problems](https://en.wikipedia.org/wiki/Thundering_herd_problem) if many virtual machines that were provisioned together try to renew their certificates at the same time.
 
 Here's an example of setting up renewal via `cron` on a Debian-based system:
 


### PR DESCRIPTION
Hey @dopey, while researching systemd I came up with a fresh new way to do renewals—using systemd timers and service unit templates—that offers a bit more flexibility, uses less resources, and is easier to configure than `step ca renew --daemon`.

We may want to address smallstep/cli#398 before we merge this, so I can remove the jq dependency from this and simplify the service template.
