### PR TITLE
Windows install instructions for step-cli

### DIFF
--- a/step-cli/installation.mdx
+++ b/step-cli/installation.mdx
@@ -67,11 +67,12 @@ Open PowerShell as an Administartor and run the following:
 ```
 PS C:\Users\Administrator> curl.exe -LO https://github.com/smallstep/cli/releases/download/v0.15.3/step_windows_0.15.3_amd64.zip
 PS C:\Users\Administrator> Expand-Archive -LiteralPath .\step_windows_0.15.3_amd64.zip
-PS C:\Users\Administrator> cd .\step_windows_0.15.3_amd64\output\binary\windows\bundle\tmp.womx\step_0.15.3\bin
-PS C:\Users\Administrator\step_windows_0.15.3_amd64\output\binary\windows\bundle\tmp.womx\step_0.15.3\bin> .\step.exe --version
+PS C:\Users\Administrator> .\step.exe --version
 Smallstep CLI/0.15.3 (windows/amd64)
 Release Date: 2020-10-21 23:51 UTC
 ```
+
+Move the `step.exe` binary wherever you'd like it to be in your path.
 
 ### Testing your installation
 

--- a/step-cli/installation.mdx
+++ b/step-cli/installation.mdx
@@ -33,7 +33,9 @@ Install `step` via [Homebrew](https://brew.sh/):
 brew install step
 ```
 
-### Debian Linux
+### Linux
+
+#### Debian Linux
 
 Download and install the Debian package from our [latest release](https://github.com/smallstep/cli/releases/latest):
 
@@ -42,7 +44,7 @@ wget https://github.com/smallstep/cli/releases/download/v0.15.3/step-cli_0.15.3_
 sudo dpkg -i step-cli_0.15.3_amd64.deb
 ```
 
-### Arch Linux
+#### Arch Linux
 
 We are using the [Arch User Repository](https://aur.archlinux.org/) to
 distribute `step` binaries for Arch Linux.
@@ -52,24 +54,34 @@ distribute `step` binaries for Arch Linux.
 
 You can use [pacman](https://www.archlinux.org/pacman/) to install the packages.
 
-### Linux (other)
+#### Linux (other)
 
 We have amd64, arm64, and armv7 releases available to download from our [latest
 release](https://github.com/smallstep/cli/releases/latest).
 
 ### Windows
 
-Download the Windows binary from our [latest
-releases](https://github.com/smallstep/cli/releases/latest) page and install it using PowerShell.
+#### Install via Scoop
+
+Install `step` via [scoop](https://scoop.sh/):
+
+```shell
+scoop bucket add smallstep https://github.com/smallstep/scoop-bucket.git
+scoop install smallstep/step
+```
+
+#### Install manually
+
+Download the Windows binary from our [latest releases](https://github.com/smallstep/cli/releases/latest) page and install it using PowerShell.
 
 Open PowerShell as an Administartor and run the following:
 
-```
-PS C:\Users\Administrator> curl.exe -LO https://github.com/smallstep/cli/releases/download/v0.15.3/step_windows_0.15.3_amd64.zip
-PS C:\Users\Administrator> Expand-Archive -LiteralPath .\step_windows_0.15.3_amd64.zip
+```shell
+PS C:\Users\Administrator> curl.exe -LO https://github.com/smallstep/cli/releases/download/v0.15.7/step_windows_0.15.7_amd64.zip
+PS C:\Users\Administrator> Expand-Archive -LiteralPath .\step_windows_0.15.7_amd64.zip
 PS C:\Users\Administrator> .\step.exe --version
-Smallstep CLI/0.15.3 (windows/amd64)
-Release Date: 2020-10-21 23:51 UTC
+Smallstep CLI/0.15.7 (windows/amd64)
+Release Date: 2021-02-18 22:18 UTC
 ```
 
 Move the `step.exe` binary wherever you'd like it to be in your path.

--- a/step-cli/installation.mdx
+++ b/step-cli/installation.mdx
@@ -57,6 +57,22 @@ You can use [pacman](https://www.archlinux.org/pacman/) to install the packages.
 We have amd64, arm64, and armv7 releases available to download from our [latest
 release](https://github.com/smallstep/cli/releases/latest).
 
+### Windows
+
+Download the Windows binary from our [latest
+releases](https://github.com/smallstep/cli/releases/latest) page and install it using PowerShell.
+
+Open PowerShell as an Administartor and run the following:
+
+```
+PS C:\Users\Administrator> curl.exe -LO https://github.com/smallstep/cli/releases/download/v0.15.3/step_windows_0.15.3_amd64.zip
+PS C:\Users\Administrator> Expand-Archive -LiteralPath .\step_windows_0.15.3_amd64.zip
+PS C:\Users\Administrator> cd .\step_windows_0.15.3_amd64\output\binary\windows\bundle\tmp.womx\step_0.15.3\bin
+PS C:\Users\Administrator\step_windows_0.15.3_amd64\output\binary\windows\bundle\tmp.womx\step_0.15.3\bin> .\step.exe --version
+Smallstep CLI/0.15.3 (windows/amd64)
+Release Date: 2020-10-21 23:51 UTC
+```
+
 ### Testing your installation
 
 ```shell-session nocopy


### PR DESCRIPTION
This isn't great because of smallstep/cli#409, but if we can fix that first then this will make a little more sense.
Also, I'm not sure where to install the `.exe` file on Windows so that it's in PATH.
