### PR TITLE
Systemd service hardening

### DIFF
--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -220,6 +220,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ProtectKernelLogs=true
   ProtectControlGroups=true
   RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+  RestrictNamespaces=yes
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -213,6 +213,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   PrivateTmp=yes
   ReadWriteDirectories=/etc/step-ca/db
   PrivateDevices=true
+  PrivateUsers=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -217,6 +217,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ProtectKernelTunables=true
   ProtectClock=true
   ProtectKernelModules=true
+  ProtectKernelLogs=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -215,6 +215,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   PrivateDevices=true
   PrivateUsers=true
   ProtectKernelTunables=true
+  ProtectClock=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -216,6 +216,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   PrivateUsers=true
   ProtectKernelTunables=true
   ProtectClock=true
+  ProtectKernelModules=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -219,6 +219,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ProtectKernelModules=true
   ProtectKernelLogs=true
   ProtectControlGroups=true
+  RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -229,6 +229,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   MemoryDenyWriteExecute=true
   ProtectProc=invisible
   ProcSubset=pid
+  SystemCallFilter=~@clock @debug @module @mount @raw-io @reboot @swap @privileged @resources @cpu-emulation @obsolete
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -228,6 +228,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   SystemCallArchitectures=native
   MemoryDenyWriteExecute=true
   ProtectProc=invisible
+  ProcSubset=pid
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -189,10 +189,9 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
 
   [Service]
   Type=simple
-  User=step
-  Group=step
-  Environment=STEPPATH=/etc/step-ca
-  WorkingDirectory=/etc/step-ca
+  Environment=STEPPATH=/var/lib/step-ca
+  WorkingDirectory=/var/lib/step-ca
+  StateDirectory=step-ca
   ExecStart=/usr/local/bin/step-ca config/ca.json --password-file=password.txt
   ExecReload=/bin/kill --signal HUP $MAINPID
   Restart=on-failure
@@ -211,7 +210,6 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ProtectSystem=full
   ProtectHome=true
   PrivateTmp=yes
-  ReadWriteDirectories=/etc/step-ca/db
   PrivateDevices=true
   PrivateUsers=true
   ProtectKernelTunables=true
@@ -230,6 +228,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ProtectProc=invisible
   ProcSubset=pid
   SystemCallFilter=~@clock @debug @module @mount @raw-io @reboot @swap @privileged @resources @cpu-emulation @obsolete
+  DynamicUser=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -218,6 +218,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ProtectClock=true
   ProtectKernelModules=true
   ProtectKernelLogs=true
+  ProtectControlGroups=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -224,6 +224,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   LockPersonality=yes
   RestrictRealtime=yes
   RestrictSUIDSGID=yes
+  RemoveIPC=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -222,6 +222,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
   RestrictNamespaces=yes
   LockPersonality=yes
+  RestrictRealtime=yes
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -223,6 +223,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   RestrictNamespaces=yes
   LockPersonality=yes
   RestrictRealtime=yes
+  RestrictSUIDSGID=yes
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -227,6 +227,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   RemoveIPC=true
   SystemCallArchitectures=native
   MemoryDenyWriteExecute=true
+  ProtectProc=invisible
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -221,6 +221,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ProtectControlGroups=true
   RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
   RestrictNamespaces=yes
+  LockPersonality=yes
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -225,6 +225,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   RestrictRealtime=yes
   RestrictSUIDSGID=yes
   RemoveIPC=true
+  SystemCallArchitectures=native
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -226,6 +226,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   RestrictSUIDSGID=yes
   RemoveIPC=true
   SystemCallArchitectures=native
+  MemoryDenyWriteExecute=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -214,6 +214,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ReadWriteDirectories=/etc/step-ca/db
   PrivateDevices=true
   PrivateUsers=true
+  ProtectKernelTunables=true
 
   [Install]
   WantedBy=multi-user.target

--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -212,6 +212,7 @@ Note: _This section requires a Linux OS running `systemd` version 229 or greater
   ProtectHome=true
   PrivateTmp=yes
   ReadWriteDirectories=/etc/step-ca/db
+  PrivateDevices=true
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
### Description
I don't have a lot of time right now but I will open this for discussion. A few settings are redundant but I like to be explicit.
Especially `PrivateUsers=true`, `ProcSubset=pid ` and `SystemCallFilter=~...` are questionable (see commit messages).
The `DynamicUser` change would be a breaking change for sure.

I would like to know how "opposed" you are to such changes. The original discussion comes from https://github.com/NixOS/nixpkgs/pull/110822#discussion_r564909712. I may not have copy pasted properly and need to test this later. I just don't have the time right now and want to know what you think about it before I put more time into this.