### PR TITLE
Fix link to scripted DB export

### DIFF
--- a/step-ca/configuration.mdx
+++ b/step-ca/configuration.mdx
@@ -2131,7 +2131,7 @@ As the interface is a key-value store, the schema is very simple. We support tab
 
 ### Exporting Data
 
-At this time `step-ca` does not have any API or interface for easily exporting data. Because the data is stored in a `noSQL` like manner, it is difficult to explore the data even when using a SQL backend like MySQL. We do have [a scripted example for accessing the DB](#scripted-export-db) to give users a jumping off point for writing their own reporting and logging tools.
+At this time `step-ca` does not have any API or interface for easily exporting data. Because the data is stored in a `noSQL` like manner, it is difficult to explore the data even when using a SQL backend like MySQL. We do have [a scripted example for accessing the DB][scripted-export-db] to give users a jumping off point for writing their own reporting and logging tools.
 
 <Alert severity="info">
   <div>


### PR DESCRIPTION
### Description

This pull request fixes the link to the gist: https://gist.github.com/dopey/89ec20f22c66c1333bf38c9b19b89758