### PR TITLE
"Offline mode" changes

### DIFF
--- a/step-ca/certificate-authority-core-concepts.mdx
+++ b/step-ca/certificate-authority-core-concepts.mdx
@@ -83,7 +83,7 @@ Certificate Authority knows to reject any attempts to renew it.
 
 ![passive revocation diagram](../../../static/images/passive-revocation.png)
 
-## Other `step-ca` operational modes
+## Other operational modes
 
 `step-ca` has a couple of non-standard modes of operation.
 

--- a/step-ca/certificate-authority-core-concepts.mdx
+++ b/step-ca/certificate-authority-core-concepts.mdx
@@ -20,58 +20,15 @@ certificate management may want to check out...
 
 ## Overview
 
-- [Online and Offline X.509 Certificate Authority](#online-and-offline-x509-certificate-authority)
-- [Other Operational Modes](#other-operational-modes)
+- [Online X.509 Certificate Authority](#online-and-offline-x509-certificate-authority)
 - [Provisioners](#provisioners)
 - [Active vs. Passive Revocation](#active-vs-passive-revocation)
+- [Other Operational Modes](#other-operational-modes)
 
-## Online and Offline X.509 Certificate Authority
+## Online X.509 Certificate Authority
 
-Certificate Authorities (CAs) tend to be either "online" or "offline" mode.
-
-
-When referring to Certificate Authorities (CAs), _offline_ generally means
-air-gapped or network isolated. However, the term _offline_ has a different
-meaning in the context of `step-ca`. When `step-ca` is online (using the
-`step-ca` server) it is responding to network requests. But `step-ca` can
-also operate "offline", without the `step-ca` server, by accessing the signing
-keys locally. We call this static, non-daemonized operation _offline mode_. Any
-further use of the term _offline_ in these docs will refer to _offline mode_ in
-the context of `step-ca` (local access only).
-
-Our tools support three modes of generating and operating a Certificate Authority (CA):
-* An online database-backed CA, using the `step-ca` daemon and `step ca` subcommand ([docs here][stateful-ca]).
-* A local (or airgapped) database-backed CA, using the `step ca` subcommand with `--offline`.
-* A minimalist, offline, stateless CA, using the `step certificate` subcommand
-  ([docs here][stateless-ca]).
-
-![](../../../static/images/cas-three-ways.png)
-
-[stateless-ca]: /docs/step-cli/basic-crypto-operations#run-an-offline-x509-certificate-authority
-[stateful-ca]: /docs/step-ca/getting-started
-
-### Example: Offline Mode
-
-It's not always practical or desirable to run an online CA.
-Smallstep provides the means to create certificates without `step-ca` running.
-`step-cli` offline mode leverages the CA's configuration, which must be available locally, to issue certificates.
-
-```shell-session nocopy
-$ step ca init --name "Local CA" --provisioner admin --dns localhost --address ":443"
-$ step ca certificate --offline foo.smallstep.com foo.crt foo.key
-```
-
-## Registration Authority (RA) mode
-
-Sometimes you may wish to run a Registration Authority (RA).
-An RA acts as a front-end to a CA, authenticating certificate requests from its clients before passing them along to an upstream Certificate Authority that will issue the certificates.
-This operational mode centralizes and simplifies CA key management, because a single backing CA can serve several RAs.
-
-In RA mode, `step-ca` currently supports two backing CA types: Another `step-ca` instance ("StepCAS"), or Google CloudCAS.
-
-![Example PKI topology with StepCAS RA Mode](/static/graphics/stepcas-ra-mode.png)
-
-See the [Registration Authority (RA) Mode](configuration#registration-authority-ra-mode) section of our Configuration Guide for more on RA mode.
+`step-ca` is an online certificate authority, meaning it runs as a server
+on the network and accepts certificate requests.
 
 ## Provisioners
 
@@ -125,6 +82,44 @@ _passively revoke_ a certificate by letting it expire and making sure the
 Certificate Authority knows to reject any attempts to renew it.
 
 ![passive revocation diagram](../../../static/images/passive-revocation.png)
+
+## Other `step-ca` operational modes
+
+`step-ca` has a couple of non-standard modes of operation.
+
+### Registration Authority (RA) mode
+
+`step-ca` can operate in Registration Authority (RA) mode.
+An RA is a server that acts as an authentication layer for an upstream signing CA.
+
+RA mode lets you separate certificate request authentication (the RA) from certificate signing operations (the CA).
+This operational mode centralizes key management:
+a single CA can serve several RAs.
+
+In RA mode, `step-ca` can peer with two kinds of upstream CA: A `step-ca` instance, or a [Google CloudCAS](https://cloud.google.com/certificate-authority-service/) authority.
+
+![Example PKI topology with StepCAS RA Mode](/static/graphics/stepcas-ra-mode.png)
+
+See the [Registration Authority (RA) Mode](configuration#registration-authority-ra-mode) section of our Configuration Guide for more on RA mode.
+
+### Offline Mode
+
+Sometimes it's useful to access a local CA offline, without running the `step-ca` server.
+For this purpose, the `step` CLI can be used in _offline mode_ (with the `--offline` flag).
+Offline mode uses the configuration, database, certificates, and keys of an existing `step-ca` installation.
+
+This table shows some of the feature differences between an online `step-ca` server, `step` CLI in offline mode, and the [`step certificate` subcommand](https://smallstep.com/docs/step-cli/basic-crypto-operations#run-an-offline-x509-certificate-authority).
+
+![](../../../static/images/cas-three-ways.png)
+
+### Example: Offline Mode
+
+Let's create a certificate without `step-ca`:
+
+```shell-session nocopy
+$ step ca init --name "Local CA" --provisioner admin --dns localhost --address ":443"
+$ step ca certificate --offline foo.smallstep.com foo.crt foo.key
+```
 
 ## Next Steps
 

--- a/step-cli/basic-crypto-operations.mdx
+++ b/step-cli/basic-crypto-operations.mdx
@@ -17,7 +17,7 @@ You don't need to run an online Certificate Authority to create certificates and
 
 Here's a few common uses of the `step` command:
 
-- [Create certificates with `step`](#create-certificates-with-step)
+- [Create and work with X.509 certificates](#create-and-work-with-x509-certificates)
 - [Get a TLS Certificate From Let's Encrypt](#get-a-tls-certificate-from-lets-encrypt)
 - [Generate JSON Web Tokens (JWTs) and JSON Web Keys (JWKs)](#generate-json-web-tokens-jwts-and-json-web-keys-jwks)
 - [Obtain and Work With OAuth Tokens](#obtain-and-work-with-oauth-tokens)
@@ -27,7 +27,7 @@ Here's a few common uses of the `step` command:
 
 - [`step`](/docs/step-cli)
 
-## Create certificates with `step`
+## Create and work with X.509 certificates
 
 Let's take a look at the `step certificate` command group.
 

--- a/step-cli/basic-crypto-operations.mdx
+++ b/step-cli/basic-crypto-operations.mdx
@@ -17,7 +17,7 @@ You don't need to run an online Certificate Authority to create certificates and
 
 Here's a few common uses of the `step` command:
 
-- [Run an Offline X.509 Certificate Authority](#run-an-offline-x509-certificate-authority)
+- [Create certificates with `step`](#create-certificates-with-step)
 - [Get a TLS Certificate From Let's Encrypt](#get-a-tls-certificate-from-lets-encrypt)
 - [Generate JSON Web Tokens (JWTs) and JSON Web Keys (JWKs)](#generate-json-web-tokens-jwts-and-json-web-keys-jwks)
 - [Obtain and Work With OAuth Tokens](#obtain-and-work-with-oauth-tokens)
@@ -27,11 +27,21 @@ Here's a few common uses of the `step` command:
 
 - [`step`](/docs/step-cli)
 
-## Run an Offline X.509 Certificate Authority
+## Create certificates with `step`
 
-This section only covers the simplest `step certificate` offline mode of operation.
+Let's take a look at the `step certificate` command group.
 
-For everything else, see the [`step-ca` documentation](/docs/step-ca).
+The `step certificates` command group is a Swiss Army knife for working with certificates.
+You can use it to create certificate signing requests (CSRs),
+sign CSRs,
+create self-signed certificates (e.g., a root certificate authority),
+create leaf or intermediate CA certificates,
+validate and inspect certificates,
+renew certificates,
+generate certificate bundles,
+and to key-wrap private keys.
+
+Shall we try it out?
 
 ### Create a Certificate Authority
 

--- a/step-cli/index.mdx
+++ b/step-cli/index.mdx
@@ -11,7 +11,7 @@ cta:
 
 ## Introduction to `step`
 
-`step` is an easy-to-use CLI tool for building, operating, and automating Public Key Infrastructure (PKI) systems and workflows. `step` acts as front-end interface to [`step-ca`](/docs/step-ca), an online X.509 and SSH Certificate Authority (CA). `step` is also a general-purpose PKI toolkit: You can use it to run a minimalist, offline X.509 CA and to perform other basic crypto operations.
+`step` is an easy-to-use CLI tool for building, operating, and automating Public Key Infrastructure (PKI) systems and workflows. `step` acts as front-end interface to [`step-ca`](/docs/step-ca), an online X.509 and SSH Certificate Authority (CA). `step` is also a standalone, general-purpose PKI toolkit: You can use it for many common crypto and X.509 operations.
 
 ## Using `step` with `step-ca`
 
@@ -23,7 +23,7 @@ If you'd like to use `step` with `step-ca`, head over to the [`step-ca` document
 
 Here's a few common uses of the `step` command that don't require `step-ca`:
 
-- [Run a stateless, offline X.509 Certificate Authority](/docs/step-cli/basic-crypto-operations#run-an-offline-x509-certificate-authority)
+- [Create and sign X.509 certificates](/docs/step-cli/basic-crypto-operations#create-certificates-with-step)
 - [Get a TLS Certificate From Let's Encrypt](/docs/step-cli/basic-crypto-operations#get-a-tls-certificate-from-lets-encrypt)
 - [Generate JSON Web Tokens (JWTs) and JSON Web Keys (JWKs)](/docs/step-cli/basic-crypto-operations#generate-json-web-tokens-jwts-and-json-web-keys-jwks)
 - [Obtain and Work With OAuth Tokens](/docs/step-cli/basic-crypto-operations#obtain-and-work-with-oauth-tokens)

--- a/step-cli/index.mdx
+++ b/step-cli/index.mdx
@@ -23,7 +23,7 @@ If you'd like to use `step` with `step-ca`, head over to the [`step-ca` document
 
 Here's a few common uses of the `step` command that don't require `step-ca`:
 
-- [Create and sign X.509 certificates](/docs/step-cli/basic-crypto-operations#create-certificates-with-step)
+- [Create and work with X.509 certificates](/docs/step-cli/basic-crypto-operations#create-and-work-with-x509-certificates)
 - [Get a TLS Certificate From Let's Encrypt](/docs/step-cli/basic-crypto-operations#get-a-tls-certificate-from-lets-encrypt)
 - [Generate JSON Web Tokens (JWTs) and JSON Web Keys (JWKs)](/docs/step-cli/basic-crypto-operations#generate-json-web-tokens-jwts-and-json-web-keys-jwks)
 - [Obtain and Work With OAuth Tokens](/docs/step-cli/basic-crypto-operations#obtain-and-work-with-oauth-tokens)


### PR DESCRIPTION
- step-ca: Reword offline `step-ca` mode description
- step-ca: Make offline mode less prominent in the Core Concepts doc.
- step-ca: Some tweaks to how we describe RA mode
- step CLI: Reframe the `step certificates` intro description to avoid referencing to offline vs. online operation.

@devadvocado @mmalone I think this clarifies offline mode (and dials back its prominence in the docs), without the need to change the flag name in the CLI.

One important change here is to stop referring to `step certificate` as an "offline CA". It's an X.509 toolkit. With this PR, we only refer to "offline mode" in relation to `step-ca` / `step ca --offline`.

Would love your feedback.
