### PR TITLE
Missing the word "certificate" in sub-heading

### DIFF
--- a/step-ca/certificate-authority-server-production.mdx
+++ b/step-ca/certificate-authority-server-production.mdx
@@ -905,7 +905,7 @@ In this case, the certificate and key authenticate the request, so you don't nee
   >{`$ step ca revoke --cert localhost.crt --key localhost.key
 Certificate with Serial Number 59636004850364466675608080466579278406 has been revoked.`}</CodeBlock>
 
-### 4. Check that the has been revoked
+### 4. Check that the certificate has been revoked
 
 You'll get an HTTP 401 error when you try to renew it.
 


### PR DESCRIPTION
Quick fix for the docs missing the word "certificate" in sub-heading